### PR TITLE
Migrate runtime image to DHI — boogie-service

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": [
+    "github-actions",
+    "gradle",
+    "gradle-wrapper",
+    "dockerfile",
+    "docker-compose"
+  ],
+  "extends": [
+    "github>cre-security/renovate-controller",
+    "github>mitre-tdp/tdp-renovate:gradle.json5",
+    "github>mitre-tdp/tdp-renovate:docker.json5",
+    "github>mitre-tdp/tdp-renovate:github-actions.json5"
+  ],
+  "packageRules": [
+    {
+      // docker-init: moving cert payload (:latest-mitre) — keep floating, never pin its digest
+      "matchPackageNames": ["harbor.cre.gov.aws.mitre.org/cre/docker-init"],
+      "pinDigests": false,
+    },
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,16 @@
-FROM eclipse-temurin:21-jre-alpine AS deploy
+# DHI migration (stub) — tdp-roadmap #529. Runtime base swapped to the Docker Hardened Image
+# eclipse-temurin Java 21 (alpine) ref, pinned by digest. Renovate's dockerfile manager should
+# track this tag@digest pair (follow-up).
+#
+# TODO(dhi, maestro#812): the DHI base is distroless/nonroot with no shell, keytool, or
+#   update-ca-trust. Follow the merged maestro pattern (mitre-tdp/maestro#812) to complete this:
+#     - Add a cert-seeding build stage on the JDK -dev image (has keytool) that bakes the MITRE CA
+#       roots into a temurin truststore, then COPY it into this runtime stage and reference it via
+#       -Djavax.net.ssl.trustStore in the ENTRYPOINT.
+#     - Writable /tmp and /run: helm hardening (readOnlyRootFilesystem + emptyDir mounts at /tmp
+#       and /run); add -Djava.io.tmpdir=/tmp to the ENTRYPOINT.
+#     - Drop any --chown (DHI runs as a fixed nonroot user; world-readable bundle is sufficient).
+FROM harbor.cre.gov.aws.mitre.org/dhi/eclipse-temurin:21-alpine@sha256:470f6223a1cdc3cdc3627f4cc11e31c5b6c2a8c3ca81f802d049b1a17e54e397 AS deploy
 
 WORKDIR /boogie-service
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,15 @@
 #   shipped only the public temurin truststore. The cert stage below ADDS the MITRE roots (matching
 #   the maestro pattern). This is a net improvement and is required for any outbound TLS to
 #   MITRE-internal endpoints; it does not regress prior behavior for public endpoints.
-ARG TEMURIN_JDK_VERSION=21-jdk-alpine3.24-dev
-ARG TEMURIN_JDK_DIGEST=sha256:b60eaaef4af660b6b9476c612b77e3c8c998a166869797f53f444c7a5cc14f82
+ARG TEMURIN_JDK_VERSION=21-jdk-alpine-dev
+ARG TEMURIN_JDK_DIGEST=sha256:1c1f852eb32137cc82ea3f0a64ac5e3e733718325dbe17bf2ce2c58ab0ac848d
 
-ARG BUILD_INIT=harbor.cre.gov.aws.mitre.org/cre/docker-init:20260429.1415.47-adc03cd-mitre
+# docker-init is a FROM-scratch, data-only image (certs + scripts) used solely as a build-time
+# bind-mount source; its layers never ship in the runtime, so it has no runtime CVE impact. Track
+# the maintained moving tag rather than a pinned build — stale pinned builds get retention-purged
+# and break the build later. BUILD_INIT stays an ARG so a deployment can swap the per-environment
+# cert payload (mitre / gha / faa-tyrion / partner).
+ARG BUILD_INIT=harbor.cre.gov.aws.mitre.org/cre/docker-init:latest-mitre
 FROM $BUILD_INIT AS docker-init
 
 # ---- cert stage: bake the MITRE CA roots into a temurin truststore --------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,38 @@
-# DHI migration (stub) — tdp-roadmap #529. Runtime base swapped to the Docker Hardened Image
-# eclipse-temurin Java 21 (alpine) ref, pinned by digest. Renovate's dockerfile manager should
-# track this tag@digest pair (follow-up).
+# Runtime image for boogie-service on a Docker Hardened Image (DHI) base — tdp-roadmap #529.
+# Follows the merged maestro DHI pattern (mitre-tdp/maestro#812).
 #
-# TODO(dhi, maestro#812): the DHI base is distroless/nonroot with no shell, keytool, or
-#   update-ca-trust. Follow the merged maestro pattern (mitre-tdp/maestro#812) to complete this:
-#     - Add a cert-seeding build stage on the JDK -dev image (has keytool) that bakes the MITRE CA
-#       roots into a temurin truststore, then COPY it into this runtime stage and reference it via
-#       -Djavax.net.ssl.trustStore in the ENTRYPOINT.
-#     - Writable /tmp and /run: helm hardening (readOnlyRootFilesystem + emptyDir mounts at /tmp
-#       and /run); add -Djava.io.tmpdir=/tmp to the ENTRYPOINT.
-#     - Drop any --chown (DHI runs as a fixed nonroot user; world-readable bundle is sufficient).
+# The runtime base is the DHI eclipse-temurin Java 21 (alpine) image, pinned by digest. It is
+# distroless/nonroot: no shell, no keytool, no update-ca-trust. Renovate's dockerfile manager
+# tracks the tag@digest pairs below.
+#
+#   - runtime : DHI eclipse-temurin 21 (alpine), pinned by digest. Distroless, fixed nonroot user.
+#   - certs   : DHI eclipse-temurin 21 JDK dev (has a shell + keytool), used only to bake the MITRE
+#               CA roots into a temurin truststore. Not shipped; the PKCS12/JKS truststore it emits
+#               is portable to the runtime (same temurin 21).
+#
+# NOTE(dhi): the pre-DHI base (eclipse-temurin:21-jre-alpine) did NOT seed the MITRE CA roots — it
+#   shipped only the public temurin truststore. The cert stage below ADDS the MITRE roots (matching
+#   the maestro pattern). This is a net improvement and is required for any outbound TLS to
+#   MITRE-internal endpoints; it does not regress prior behavior for public endpoints.
+ARG TEMURIN_JDK_VERSION=21-jdk-alpine3.24-dev
+ARG TEMURIN_JDK_DIGEST=sha256:b60eaaef4af660b6b9476c612b77e3c8c998a166869797f53f444c7a5cc14f82
+
+ARG BUILD_INIT=harbor.cre.gov.aws.mitre.org/cre/docker-init:20260429.1415.47-adc03cd-mitre
+FROM $BUILD_INIT AS docker-init
+
+# ---- cert stage: bake the MITRE CA roots into a temurin truststore --------------------------------
+# The distroless runtime has no shell/keytool/update-ca-trust, so seed a truststore from this JDK's
+# cacerts (public roots) and add the docker-init MITRE roots here, then COPY it into the runtime.
+FROM harbor.cre.gov.aws.mitre.org/dhi/eclipse-temurin:${TEMURIN_JDK_VERSION}@${TEMURIN_JDK_DIGEST} AS certs
+USER root
+RUN --mount=type=bind,from=docker-init,src=/caasd,dst=/init \
+    cp "${JAVA_HOME}/lib/security/cacerts" /tmp/truststore \
+    && for crt in /init/certs/*.crt; do \
+         keytool -importcert -noprompt -storepass changeit -keystore /tmp/truststore \
+           -alias "mitre-$(basename "$crt" .crt)" -file "$crt"; \
+       done
+
+# ---- runtime: distroless DHI JRE ------------------------------------------------------------------
 FROM harbor.cre.gov.aws.mitre.org/dhi/eclipse-temurin:21-alpine@sha256:470f6223a1cdc3cdc3627f4cc11e31c5b6c2a8c3ca81f802d049b1a17e54e397 AS deploy
 
 WORKDIR /boogie-service
@@ -17,6 +40,26 @@ WORKDIR /boogie-service
 EXPOSE 8080
 EXPOSE 8081
 
+# MITRE-trusted truststore from the cert stage (replaces the keytool/update-ca-trust path the
+# distroless runtime cannot run). Consumed via -Djavax.net.ssl.trustStore in the ENTRYPOINT — a
+# fixed path avoids depending on the JRE's version-specific JAVA_HOME. Contains the JDK public roots
+# plus the MITRE CAs.
+COPY --from=certs /tmp/truststore /boogie-service/certs/cacerts
+
+# DHI runs as a fixed nonroot user and the JAR only needs to be world-readable, so no --chown.
 COPY build/libs/boogie-service.jar .
 
-ENTRYPOINT ["java","-Djava.security.manager=allow","-XX:MaxRAMPercentage=75.0","--add-opens=java.base/sun.nio.ch=ALL-UNNAMED","--add-opens=java.base/java.io=ALL-UNNAMED","--add-opens=java.base/java.lang=ALL-UNNAMED","--add-opens=java.base/java.nio=ALL-UNNAMED","--add-opens=java.base/java.util=ALL-UNNAMED","-jar","./boogie-service.jar"]
+# /tmp must be writable at runtime; the helm chart mounts an emptyDir at /tmp with
+# readOnlyRootFilesystem. -Djava.io.tmpdir=/tmp keeps the JVM temp dir explicit.
+ENTRYPOINT ["java", \
+    "-Djava.io.tmpdir=/tmp", \
+    "-Djavax.net.ssl.trustStore=/boogie-service/certs/cacerts", \
+    "-Djavax.net.ssl.trustStorePassword=changeit", \
+    "-Djava.security.manager=allow", \
+    "-XX:MaxRAMPercentage=75.0", \
+    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED", \
+    "--add-opens=java.base/java.io=ALL-UNNAMED", \
+    "--add-opens=java.base/java.lang=ALL-UNNAMED", \
+    "--add-opens=java.base/java.nio=ALL-UNNAMED", \
+    "--add-opens=java.base/java.util=ALL-UNNAMED", \
+    "-jar", "./boogie-service.jar"]

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -99,8 +99,13 @@ spec:
             - name: SPRING_CONFIG_LOCATION
               value: 'classpath:/application.yaml,file:/config/application.yaml'
           volumeMounts:
+            # readOnlyRootFilesystem is true (above); the DHI distroless runtime still needs a
+            # writable /tmp (JVM java.io.tmpdir) and /run, so back both with emptyDir mounts.
             - mountPath: /tmp
               name: tmp-dir
+              readOnly: false
+            - mountPath: /run
+              name: run-dir
               readOnly: false
             - name: {{ .Values.configVolume.name }}
               mountPath: '{{ .Values.configVolume.mountPath }}'
@@ -108,6 +113,8 @@ spec:
 
       volumes:
         - name: tmp-dir
+          emptyDir: { }
+        - name: run-dir
           emptyDir: { }
         - name: {{ .Values.configVolume.name }}
           configMap:


### PR DESCRIPTION
Migrates the boogie-service runtime image to a Docker Hardened Image (DHI), applying the merged maestro DHI pattern (mitre-tdp/maestro#812).

### Base image
- runtime: `harbor.cre.gov.aws.mitre.org/dhi/eclipse-temurin:21-alpine@sha256:470f6223a1cdc3cdc3627f4cc11e31c5b6c2a8c3ca81f802d049b1a17e54e397` (real Java-21 DHI pin, confirmed — distroless, fixed nonroot user).
- cert stage: `harbor.cre.gov.aws.mitre.org/dhi/eclipse-temurin:21-jdk-alpine-dev@sha256:1c1f852eb32137cc82ea3f0a64ac5e3e733718325dbe17bf2ce2c58ab0ac848d` (JDK with shell + keytool; not shipped). Normalized to the current floating-tag-pinned digest for consistency with the maestro DHI pattern.

### Framework
boogie-service is **Spring Boot 3** (not Quarkus). The JVM default JSSE truststore (`-Djavax.net.ssl.trustStore`) is the only cert mechanism required — the Quarkus TLS-registry PEM (`/caasd/certs/mitre_certs.pem` + `copy-certs.sh`) does **not** apply here and was intentionally not added.

### Done (per maestro #812)
- **docker-init on `:latest-mitre`** — switched off the stale pinned build (`…20260429.1415.47-adc03cd-mitre`) to the maintained moving tag `harbor.cre.gov.aws.mitre.org/cre/docker-init:latest-mitre`, so the build does not break when the pinned build is retention-purged. `BUILD_INIT` stays an `ARG` for per-environment cert-payload selection (mitre / gha / faa-tyrion / partner). docker-init is a `FROM scratch` data-only image used only as a build-time bind-mount source — no runtime CVE impact.
- **Cert / truststore stage** — the distroless runtime has no shell/`keytool`/`update-ca-trust`, so a JDK `-dev` build stage seeds a temurin truststore from the JDK `cacerts` and imports the MITRE CA roots from `docker-init`. The truststore is `COPY`ed to `/boogie-service/certs/cacerts` and consumed via `-Djavax.net.ssl.trustStore` in the ENTRYPOINT.
  - Note: the pre-DHI base (`eclipse-temurin:21-jre-alpine`) did **not** seed MITRE roots (public truststore only). This PR **adds** them, matching the maestro pattern — a net improvement, no regression for public endpoints.
- **`-Djava.io.tmpdir=/tmp`** added to the ENTRYPOINT.
- **No `--chown`** — none was present; documented why it is unnecessary (DHI fixed nonroot user + world-readable bundle).
- **helm hardening** — the chart already sets `readOnlyRootFilesystem: true`, runs nonroot (pod `securityContext`), and mounts an `emptyDir` at `/tmp`. This PR adds the `/run` `emptyDir` mount to match the DHI pattern. `helm lint` passes.

### Outstanding / TODO
- **`docker build` not run** — `build/libs/boogie-service.jar` is not present in the working tree (no Gradle build artifact); CI builds the JAR before the image build. The Dockerfile was validated by inspection; `helm lint` passes.
- **JDK `-dev` digest** — pinned to the current `21-jdk-alpine-dev@sha256:1c1f852…`. Renovate's dockerfile manager should keep both `tag@digest` pairs current.
- **Pod `runAsUser: 10000 / runAsGroup: 10001`** — the chart hardcodes these in the pod `securityContext`, overriding the DHI image's built-in nonroot user. Harmless with the world-readable bundle; left as-is.

### wizcli CVE scan
Not completed: the wizcli session was not authenticated at scan time and could not be re-authenticated non-interactively. Re-run `wizcli dir scan` (repo) and `wizcli docker scan -i …/dhi/eclipse-temurin:21-alpine@sha256:470f62…` once authed; output is not committed.

Part of mitre-tdp/tdp-roadmap#529

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Renovate: dockerfile manager enabled.** `.github/renovate.json5` now lists `dockerfile` + `docker-compose` in `enabledManagers` and extends `github>mitre-tdp/tdp-renovate:docker.json5`, so Renovate tracks the DHI `FROM …@sha256:` pins in this PR and digest-bumps them. The `harbor.cre.gov.aws.mitre.org/cre/docker-init` cert payload is kept on its moving `:latest-mitre` tag (`pinDigests: false`) — never digest-pinned.